### PR TITLE
Update GitHub Actions for Node 24 runtime

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: Setup Node.js
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v6
       with:
         node-version: '24'
         cache: 'npm'


### PR DESCRIPTION
Updates GitHub Actions workflow action versions to releases that run on Node.js 24, removing Node.js 20 JavaScript action deprecation warnings before GitHub-hosted runners switch defaults on June 2, 2026.

This is a mechanical workflow-only change from an org-wide scan. It also updates older checkout/setup/action versions that still advertised Node.js 12 or 16 runtimes where a Node.js 24 successor is available.